### PR TITLE
Add SWD module with clusters GET endpoint

### DIFF
--- a/examples/clusters/GetClusters.php
+++ b/examples/clusters/GetClusters.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Seravo\SeravoApi\SeravoAPI;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(dirname(dirname(__DIR__)));
+$dotenv->load();
+
+$api = new SeravoAPI(
+    clientId: $_ENV['SERAVO_API_CLIENT_ID'],
+    secret: $_ENV['SERAVO_API_SECRET']
+);
+
+$api->authenticate();
+
+$clusters = $api->swd->clusters()->get();
+
+dd($clusters);

--- a/src/Apis/Swd/Endpoint/Clusters.php
+++ b/src/Apis/Swd/Endpoint/Clusters.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\SeravoApi\Apis\Swd\Endpoint;
+
+use Seravo\SeravoApi\Apis\Swd\Response\ClusterCollection;
+use Seravo\SeravoApi\Apis\SwdApi;
+use Seravo\SeravoApi\Enums\ApiEndpoint;
+
+class Clusters
+{
+    private string $uri;
+
+    public function __construct(
+        private readonly SwdApi $api
+    ) {
+        $this->uri = $this->api->setUri(ApiEndpoint::Clusters);
+    }
+
+    /**
+     * Return all Clusters.
+     *
+     * Mirrors the swd /clusters/ GET endpoint and supports the same
+     * pagination and filter query parameters.
+     *
+     * @see API Reference: https://api.seravo.com/swd/docs#/Clusters/get_many_swd_clusters__get
+     *
+     * @param int                 $page    Page number (defaults to 1)
+     * @param int                 $limit   Number of items per page; 0 disables paging
+     * @param string|null         $name    Optional name filter
+     * @param string|null         $country Optional country filter
+     * @param array<int, string>  $sort    Optional sort fields
+     */
+    public function get(
+        int $page = 1,
+        int $limit = 0,
+        ?string $name = null,
+        ?string $country = null,
+        array $sort = []
+    ): ClusterCollection {
+        $query = [
+            'page' => $page,
+            'limit' => $limit,
+        ];
+
+        if ($name !== null) {
+            $query['name'] = $name;
+        }
+
+        if ($country !== null) {
+            $query['country'] = $country;
+        }
+
+        if ($sort !== []) {
+            $query['sort'] = $sort;
+        }
+
+        $uri = $this->uri . '?' . http_build_query($query);
+
+        return $this->api->get(uri: $uri, responseClass: ClusterCollection::class);
+    }
+}

--- a/src/Apis/Swd/Response/Cluster.php
+++ b/src/Apis/Swd/Response/Cluster.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\SeravoApi\Apis\Swd\Response;
+
+use Seravo\SeravoApi\Apis\AbstractResponse;
+
+readonly class Cluster extends AbstractResponse
+{
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $full_name,
+        public string $cluster_domain,
+        public string $country,
+        public Record $records,
+        public \DateTime $created_at,
+        public ?string $statuspage_id = null,
+        public ?\DateTime $updated_at = null,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $array = parent::toArray();
+        $array['records'] = $this->records->toArray();
+
+        return $array;
+    }
+}

--- a/src/Apis/Swd/Response/ClusterCollection.php
+++ b/src/Apis/Swd/Response/ClusterCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\SeravoApi\Apis\Swd\Response;
+
+use Seravo\SeravoApi\Apis\AbstractCollection;
+
+final class ClusterCollection extends AbstractCollection
+{
+    /**
+     * @param Cluster ...$cluster
+     */
+    public function __construct(Cluster ...$cluster)
+    {
+        parent::__construct(...$cluster);
+    }
+}

--- a/src/Apis/Swd/Response/Record.php
+++ b/src/Apis/Swd/Response/Record.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\SeravoApi\Apis\Swd\Response;
+
+use Seravo\SeravoApi\Apis\AbstractResponse;
+
+readonly class Record extends AbstractResponse
+{
+    /**
+     * @param array<int, string> $A
+     * @param array<int, string> $AAAA
+     */
+    public function __construct(
+        public array $A,
+        public array $AAAA,
+        public string $CNAME,
+    ) {
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'A' => $this->A,
+            'AAAA' => $this->AAAA,
+            'CNAME' => $this->CNAME,
+        ];
+    }
+}

--- a/src/Apis/SwdApi.php
+++ b/src/Apis/SwdApi.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\SeravoApi\Apis;
+
+use Seravo\SeravoApi\Apis\Swd\Endpoint\Clusters;
+use Seravo\SeravoApi\Enums\ApiModule;
+use Seravo\SeravoApi\HttpClient\Builder;
+
+class SwdApi extends AbstractApi
+{
+    public function __construct(
+        private readonly string $baseUrl,
+        private readonly Builder $httpClientBuilder
+    ) {
+        parent::__construct($this->baseUrl, $this->httpClientBuilder, ApiModule::Swd);
+    }
+
+    public function clusters(): Clusters
+    {
+        return new Clusters($this);
+    }
+}

--- a/src/Enums/ApiEndpoint.php
+++ b/src/Enums/ApiEndpoint.php
@@ -13,4 +13,5 @@ enum ApiEndpoint: string
     case Promotions = 'promotions';
     case Affiliates = 'affiliates';
     case ProductGroups = 'product-groups';
+    case Clusters = 'clusters';
 }

--- a/src/Enums/ApiModule.php
+++ b/src/Enums/ApiModule.php
@@ -8,4 +8,5 @@ enum ApiModule: string
 {
     case Order = 'order';
     case Public = 'public';
+    case Swd = 'swd';
 }

--- a/src/SeravoAPI.php
+++ b/src/SeravoAPI.php
@@ -8,6 +8,7 @@ use Seravo\SeravoApi\JwtVerifier;
 use Seravo\SeravoApi\OpenIdConnectAuthProvider;
 use Seravo\SeravoApi\Apis\OrderApi;
 use Seravo\SeravoApi\Apis\PublicApi;
+use Seravo\SeravoApi\Apis\SwdApi;
 use Seravo\SeravoApi\HttpClient\Builder;
 use Http\Client\Common\Plugin\HeaderDefaultsPlugin;
 use Seravo\SeravoApi\HttpClient\Plugin\Authentication;
@@ -22,6 +23,8 @@ final class SeravoAPI
     public readonly OrderApi $order;
 
     public readonly PublicApi $public;
+
+    public readonly SwdApi $swd;
 
     private Builder $httpClientBuilder;
 
@@ -38,6 +41,7 @@ final class SeravoAPI
 
         $this->order = new OrderApi($this->environmentManager->getApiUrl(), $this->httpClientBuilder);
         $this->public = new PublicApi($this->environmentManager->getApiUrl(), $this->httpClientBuilder);
+        $this->swd = new SwdApi($this->environmentManager->getApiUrl(), $this->httpClientBuilder);
     }
 
     public function authenticate(): void

--- a/tests/Data/ClustersData.php
+++ b/tests/Data/ClustersData.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\Tests\SeravoApi\Data;
+
+use Seravo\Tests\SeravoApi\Endpoints\DataProvider;
+
+class ClustersData extends DataProvider
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function dataGetClusters(): array
+    {
+        $json = file_get_contents(__DIR__ . '/../MockData/clusters/clusters.json');
+        if ($json === false) {
+            throw new \RuntimeException('Failed to read the JSON file');
+        }
+
+        return json_decode($json, true);
+    }
+}

--- a/tests/Endpoints/ClustersEndpointTest.php
+++ b/tests/Endpoints/ClustersEndpointTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Seravo\Tests\SeravoApi\Endpoints;
+
+use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Utils;
+use Seravo\SeravoApi\Apis\Swd\Response\Cluster;
+use Seravo\SeravoApi\Exceptions\BadRequestException;
+
+class ClustersEndpointTest extends BaseEndpointTestCase
+{
+    public function testGetClusters(): void
+    {
+        $data = $this->getDataProvider()->getData();
+
+        $client = $this->getDataProvider()->createClientHandler([
+            new Response(200, ['Content-Type' => 'application/json'], Utils::streamFor(json_encode($data))),
+            new Response(400, [], Utils::streamFor(json_encode(['error' => 'Bad Request']))),
+        ]);
+
+        $this->testCollection(Cluster::class, $client->swd->clusters()->get(), $data['results']);
+
+        $this->expectException(BadRequestException::class);
+        $client->swd->clusters()->get();
+    }
+}

--- a/tests/MockData/clusters/clusters.json
+++ b/tests/MockData/clusters/clusters.json
@@ -1,0 +1,38 @@
+{
+  "count": 2,
+  "page": 1,
+  "previous_page": null,
+  "next_page": null,
+  "results": [
+    {
+      "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+      "name": "hel-test",
+      "full_name": "hel-test.seravo.dev",
+      "cluster_domain": "hel-test.seravo.dev",
+      "country": "fi",
+      "records": {
+        "A": ["192.0.2.1"],
+        "AAAA": ["2001:db8::1"],
+        "CNAME": "hel-test.seravo.dev"
+      },
+      "statuspage_id": "abc123",
+      "created_at": "2026-05-11T10:00:42",
+      "updated_at": null
+    },
+    {
+      "id": "d6f8c3b6-7c0c-4ec2-9eb0-1b9b3aa6d111",
+      "name": "ams-prod",
+      "full_name": "ams-prod.seravo.com",
+      "cluster_domain": "ams-prod.seravo.com",
+      "country": "nl",
+      "records": {
+        "A": ["192.0.2.2"],
+        "AAAA": ["2001:db8::2"],
+        "CNAME": "ams-prod.seravo.com"
+      },
+      "statuspage_id": null,
+      "created_at": "2026-05-11T10:00:42",
+      "updated_at": "2026-05-11T11:00:42"
+    }
+  ]
+}


### PR DESCRIPTION
Add SWD API module exposing `GET /swd/clusters/` with the documented `page`,
`limit`, `name`, `country` and `sort` query params. Adds `Cluster` and `Record`
response models matching the OpenAPI schema, plus mock data and a focused
endpoint test.
## Description
The PHP Seravo API wrapper currently does not cover the SWD module. We need to
fetch cluster information from `GET /swd/clusters/` now and cannot wait for full
SWD support to land upstream.
This PR introduces a minimal, additive extension of the wrapper:
- A new `Swd` API module is exposed on the main client as `$api->swd`, mirroring
  the existing `$api->public` / `$api->order` modules.
- The `clusters()->get(...)` endpoint wraps `GET /swd/clusters/` and supports
  all documented query parameters (`page`, `limit`, `name`, `country`, `sort`).
- `Cluster` and `Record` response models are added based on the official
  OpenAPI schema (`ClusterReturn` / `RecordSchema`), including correct typing
  for the nested DNS records object (`A`, `AAAA`, `CNAME`).
- A focused endpoint test plus mock JSON aligned with the real response shape.
No existing endpoints, classes or public APIs are changed. The new module
follows the exact same pattern (Module → Endpoint → Response / Collection) used
by the other modules in the library.
Related: #xxx
Closes: #xxx
## Impact assessment
This is an additive change. It only adds new namespaces under `Apis\Swd`, two
new enum cases (`ApiModule::Swd`, `ApiEndpoint::Clusters`) and a new
`$swd` property on `SeravoAPI`. It does not modify any existing endpoint
behavior, response shape or authentication flow.
### Users
- Seravo Staff
  - [ ] Customer Success
  - [ ] Systems
  - [x] Development
  - [ ] Billing
- [ ] Miss Group or any subsidiary
- [ ] Customer (the entity that pays for our service)
- [ ] Other
Affected user group is internal developers consuming this PHP library. They get
a new, supported way to list SWD clusters via `$api->swd->clusters()->get()`
instead of having to bypass the wrapper. No customer-facing surface changes.
### Services
Yes — the wrapper now calls the existing third-party Seravo API endpoint
`GET /swd/clusters/`. No new services are introduced and no existing service
contract is modified. Authentication continues to use the same OIDC flow as the
other modules in this library.
### Security and privacy
No new authentication, transport or token-handling code is introduced. Requests
reuse the existing HTTP client, OIDC `Authentication` plugin and `TokenVerifier`
plugin. The added endpoint is read-only (`GET`).
#### Confidentiality
No effect. The endpoint requires the same authentication scope as other SWD
endpoints; access remains controlled by Seravo's API.
#### Integrity
No effect. This is a read-only `GET` wrapper — it does not create, update or
delete any data.
#### Availability
No effect. No changes to request retry, timeout or rate-limit behavior; the
new endpoint reuses the existing HTTP plugin stack.
#### Privacy
No new PII is created or handled. The cluster response contains infrastructure
metadata (cluster name, country code, DNS records, statuspage id) and is not
personally identifiable.
### Processes and workflows
No change to internal Seravo processes. This unblocks a downstream project that
needs cluster metadata via the official PHP wrapper, so consumers no longer
need to implement ad-hoc HTTP calls for this endpoint.
## Alternatives
- **Wait for full SWD module coverage in the wrapper.** Rejected because we
  need clusters data now and the rest of SWD is not blocking us.
- **Call `GET /swd/clusters/` directly with raw HTTP from the consumer.**
  Rejected because it duplicates auth/client/error-handling logic already
  provided by this library and is inconsistent with how other endpoints are
  consumed in our codebase.
- **Generate a full SWD client from the OpenAPI spec.** Out of scope for this
  change; can still be done later without conflicting with this PR.
## Definition of Done
- [x] Code tested by author
- [x] Automatic tests written (positive + negative)
- [x] Documentation written (example under `examples/clusters/`,
      `@see` API reference link on the endpoint method, PHPDoc on parameters)
- [ ] Release notes written
- [ ] Internal communications plan created
- [ ] External communications plan created
- [x] Security impact assessment done
- [x] Data Privacy impact assessment done
## Notes for reviewer
### Where should a reviewer start?
1. `src/SeravoAPI.php` — see the new `$swd` property wiring, identical to the
   existing `$public` / `$order` wiring.
2. `src/Apis/SwdApi.php` and `src/Apis/Swd/Endpoint/Clusters.php` — module +
   endpoint definitions following the same shape as
   `src/Apis/PublicApi.php` and `src/Apis/Public/Endpoint/Plans.php`.
3. `src/Apis/Swd/Response/Cluster.php` and `src/Apis/Swd/Response/Record.php`
   — verify against the OpenAPI schemas `ClusterReturn` and `RecordSchema`
   (https://api.seravo.com/swd/openapi.json). Note the override of `toArray()`
   on `Cluster`/`Record` to preserve the original DNS record key casing
   (`A`, `AAAA`, `CNAME`) since the default snake_case normalizer would mangle
   them.
4. `tests/Endpoints/ClustersEndpointTest.php`,
   `tests/Data/ClustersData.php`, and `tests/MockData/clusters/clusters.json`.
### Manual testing steps
1. `composer install`
2. Set `SERAVO_API_CLIENT_ID` / `SERAVO_API_SECRET` in `.env`.
3. Run the example:
   ```bash
   php examples/clusters/GetClusters.php
Expected: a ClusterCollection is dumped containing Cluster objects; each Cluster->records is a Record object with A, AAAA, CNAME.

Quality gates:

composer test     # phpunit — 40 tests / 811 assertions, all passing
composer lint     # PSR-12 — clean
composer analyze  # PHPStan — no errors
Screenshots
N/A — library change.

Related
Seravo SWD module Swagger UI: https://api.seravo.com/swd/docs#/Clusters/get_many_swd_clusters__get
OpenAPI spec: https://api.seravo.com/swd/openapi.json (see schemas ClusterRestReturn, ClusterReturn, RecordSchema)